### PR TITLE
fix: honor supervisor filter in performance requests

### DIFF
--- a/src/components/PerformanceTable.vue
+++ b/src/components/PerformanceTable.vue
@@ -224,7 +224,7 @@ const roleOptions = computed(() => {
 })
 
 const fetchData = async () => {
-  const params = { ...props.filters, page: currentPage.value, limit: perPage.value }
+  const params = { supervisorId: 'all', ...props.filters, page: currentPage.value, limit: perPage.value }
   if (nameFilter.value) params.name = nameFilter.value
   if (roleFilter.value) params.role = roleFilter.value
   try {
@@ -241,15 +241,21 @@ watch(
   newFilters => {
     nameFilter.value = newFilters?.name || ''
     roleFilter.value = newFilters?.role || ''
-    currentPage.value = 1
-    fetchData()
+    if (currentPage.value !== 1) {
+      currentPage.value = 1
+    } else {
+      fetchData()
+    }
   },
   { deep: true }
 )
 
 watch([nameFilter, roleFilter, perPage], () => {
-  currentPage.value = 1
-  fetchData()
+  if (currentPage.value !== 1) {
+    currentPage.value = 1
+  } else {
+    fetchData()
+  }
 })
 
 watch(currentPage, fetchData)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -85,7 +85,8 @@ getGoals: (period, startDate, endDate, supervisorId, goalType, page, limit) =>
 
 // Performance service
 export const performanceService = {
-  getTeamPerformance: (filters) => api.get("/performance/team", { params: filters }),
+  getTeamPerformance: (filters = {}) =>
+    api.get("/performance/team", { params: { supervisorId: 'all', ...filters } }),
   getRepresentativeDetails: (id, filters) => api.get(`/performance/representative/${id}`, { params: filters }),
 }
 

--- a/src/views/DashboardGerenteComercial.vue
+++ b/src/views/DashboardGerenteComercial.vue
@@ -349,7 +349,7 @@
         <!-- Tabela -->
         <PerformanceTable
           v-if="teamPerformance"
-          :team-members="teamPerformance.teamMembers"
+          :filters="filters"
           @drill-down="handleDrillDown"
         />
 


### PR DESCRIPTION
## Summary
- pass filter object to performance table so it includes supervisorId
- default supervisorId to `all` in table fetch and service layer
- avoid duplicate fetches on page reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a498cfd560832e9bb00e245d479e94